### PR TITLE
Adding support for config field to docker layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ conda-docker Change Log
 
 
 <!-- current developments -->
+**Added:**
+
+* Adding support for setting docker v1 layer config e.g. ENV, LABEL, CMD, ENTRYPOINT etc.
 
 ## v0.0.1
 **Added:**

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Examples using Library
 Downloading docker images without docker!
 
 ```python
-from docker_envs.registry.client import pull_image
+from conda_docker.registry.client import pull_image
 
 image = pull_image('frolvlad/alpine-glibc', 'latest')
 ```
@@ -45,25 +45,25 @@ image = pull_image('frolvlad/alpine-glibc', 'latest')
 Modify docker image from filesystem
 
 ```python
-from docker_envs.docker.base import Image
-from docker_envs.registry.client import pull_image
-from docker_envs.conda import conda_file_filter
+from conda_docker.docker.base import Image
+from conda_docker.registry.client import pull_image
 
 image = pull_image('continuumio/miniconda3', 'latest')
 image.remove_layer()
 image.name = 'this-is-a-test'
-image.add_layer_path('./', filter=conda_file_filter())
+image.add_layer_path('./')
 image.add_layer_contents({
     'this/is/a/test1': b'this is test 1',
     'this/is/a/test2': b'this is test 2'
 })
+image.layers[0].config['Env'].append('FOO=BAR')
 image.write_file('example-filter.tar')
 ```
 
 Build conda docker image from library
 
 ```python
-from docker_envs.conda import build_docker_environment
+from conda_docker.conda import build_docker_environment
 
 build_docker_environment(
     base_image='frolvlad/alpine-glibc:latest',

--- a/conda_docker/docker/base.py
+++ b/conda_docker/docker/base.py
@@ -13,7 +13,7 @@ from conda_docker.docker.tar import (
 
 class Layer:
     def __init__(
-        self, id, parent, architecture, os, created, author, checksum, size, content
+        self, id, parent, architecture, os, created, author, checksum, size, content, config=None
     ):
         self.created = created
         self.author = author
@@ -24,6 +24,30 @@ class Layer:
         self.size = size
         self.checksum = checksum
         self.content = content
+        self.config = config or {
+            "Hostname": "",
+            "Domainname": "",
+            "User": "root",
+            "AttachStdin": False,
+            "AttachStdout": False,
+            "AttachStderr": False,
+            "Tty": False,
+            "OpenStdin": False,
+            "StdinOnce": False,
+            "Env": [
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            ],
+            "Cmd": ["/bin/bash"],
+            "ArgsEscaped": True,
+            "Image": "todo-implement",
+            "Volumes": None,
+            "WorkingDir": "",
+            "Entrypoint": ["/bin/sh", "-c"],
+            "OnBuild": None,
+            "Labels": {
+                "CONDA_DOCKER": "0.0.1"
+            }
+        }
 
     def list_files(self):
         tar = tarfile.TarFile(fileobj=io.BytesIO(self.content))

--- a/conda_docker/docker/base.py
+++ b/conda_docker/docker/base.py
@@ -3,6 +3,7 @@ import tarfile
 import secrets
 from datetime import datetime, timezone
 
+from conda_docker import __version__ as VERSION
 from conda_docker.docker.tar import (
     parse_v1,
     write_v1,
@@ -45,7 +46,7 @@ class Layer:
             "Entrypoint": ["/bin/sh", "-c"],
             "OnBuild": None,
             "Labels": {
-                "CONDA_DOCKER": "0.0.1"
+                "CONDA_DOCKER": VERSION,
             }
         }
 

--- a/conda_docker/docker/tar.py
+++ b/conda_docker/docker/tar.py
@@ -35,6 +35,7 @@ def _parse_v1_layer(tar, layer_id):
         author=d.get("author"),
         checksum=d.get("checksum"),
         size=d.get("size"),
+        config=d.get('config'),
         content=content,
     )
 
@@ -82,9 +83,10 @@ def write_v1_layer_metadata(layer):
         "checksum",
     }
 
-    return json.dumps(
-        {k: getattr(layer, k) for k in keys if getattr(layer, k) is not None}
-    ).encode("utf-8")
+    metadata = {k: getattr(layer, k) for k in keys if getattr(layer, k) is not None}
+    metadata['config'] = layer.config
+    metadata['container_config'] = layer.config
+    return json.dumps(metadata).encode('utf-8')
 
 
 def write_v1_repositories(image):

--- a/conda_docker/registry/client.py
+++ b/conda_docker/registry/client.py
@@ -54,6 +54,7 @@ def pull_image(image, tag):
                 author=d.get("author"),
                 checksum=d.get("checksum"),
                 size=d.get("size"),
+                config=d.get("config"),
                 content=digest,
             )
         )


### PR DESCRIPTION
Need a good way to test this.

I ran 

```
from conda_docker.docker.base import Image
from conda_docker.registry.client import pull_image

image = pull_image('continuumio/miniconda3', 'latest')
image.remove_layer()
image.name = 'this-is-a-test'
image.add_layer_path('./')
image.add_layer_contents({
    'this/is/a/test1': b'this is test 1',
    'this/is/a/test2': b'this is test 2'
})
image.layers[0].config['Env'].append('FOO=BAR')
image.write_file('example-filter.tar')
```

This added the environment variable FOO. In general you should be able to update all docker settings now: LABEL, ENV, ENTRYPOINT, CMD, etc. Note that the first layer is the only layer looked at for docker settings... v2 changes this behavior by not storing the config in layers. But since this implements only the v1 spec I chose the v1 spec way of updating.