### PR TITLE
Layering

### DIFF
--- a/conda_docker/cli.py
+++ b/conda_docker/cli.py
@@ -63,6 +63,16 @@ def init_subcommand_build(subparser):
         "mamba (if available), and the user's conda otherwise.",
     )
     parser.add_argument(
+        "--layering-strategy",
+        dest="layering_strategy",
+        default="layered",
+        choices={"layered", "single"},
+        help="The strategy to employ when adding layers to the image:\n"
+        "* single: put all packages into a single layer\n"
+        "* layered (default): try to place each package in its own layer.\n"
+        "    noarch packages & leaf packages.",
+    )
+    parser.add_argument(
         "package_specs",
         nargs="*",
         help="packages specs to install in image if environment or prefix not given",
@@ -101,6 +111,7 @@ def handle_conda_build(args):
         download_dir,
         user_conda,
         channels_remap,
+        layering_strategy=args.layering_strategy,
     )
 
 

--- a/conda_docker/conda.py
+++ b/conda_docker/conda.py
@@ -12,6 +12,7 @@ import tempfile
 import subprocess
 
 from conda.exports import download
+
 try:
     from conda import __version__ as CONDA_INTERFACE_VERSION
 
@@ -22,6 +23,7 @@ except ImportError:
         f"with sys.prefix: {sys.prefix}"
     )
 from conda.models.channel import all_channel_urls
+
 try:
     from conda.models.records import PackageCacheRecord
 except ImportError:
@@ -195,9 +197,7 @@ def precs_from_package_specs(
     with timer(LOGGER, "loading repodata"):
         used_channels = {f"{x['base_url']}/{x['platform']}" for x in listing}
         repodatas = load_repodatas(
-            download_dir,
-            channels=used_channels,
-            channels_remap=channels_remap,
+            download_dir, channels=used_channels, channels_remap=channels_remap,
         )
 
     # now, create PackageCacheRecords
@@ -208,7 +208,7 @@ def precs_from_package_specs(
         plat = package.pop("platform")
         channel = f"{package['base_url']}/{plat}"
         url = f"{channel}/{fn}"
-        pkg_repodata = repodatas[channel]['packages'][fn]
+        pkg_repodata = repodatas[channel]["packages"][fn]
         md5 = pkg_repodata["md5"]
         package_tarball_full_path = os.path.join(download_dir, fn)
         extracted_package_dir = os.path.join(download_dir, dist_name)
@@ -497,6 +497,7 @@ def chroot_install(
         else:
             shutil.rmtree(entry)
 
+
 def add_single_conda_layer(image, hostpath, arcpath=None, filter=None):
     LOGGER.info("adding single conda environment layer")
     with timer(LOGGER, "adding single conda environment layer"):
@@ -515,13 +516,17 @@ def _paths_from_record(record, hostpath):
     paths = {os.path.join(host_conda_opt, f): "/opt/conda/" + f for f in files}
     paths.update({os.path.dirname(k): os.path.dirname(v) for k, v in paths.items()})
     # read package metadata
-    paths[dist_path] = dist_path[len(hostpath):]
+    paths[dist_path] = dist_path[len(hostpath) :]
     meta_json = os.path.join(host_conda_opt, "conda-meta", dist_name + ".json")
-    paths[meta_json] = meta_json[len(hostpath):]
+    paths[meta_json] = meta_json[len(hostpath) :]
     for root, dirnames, filenames in os.walk(dist_path):
-        arcroot = root[len(hostpath):]
-        paths.update({os.path.join(root, d): os.path.join(arcroot, d) for d in dirnames})
-        paths.update({os.path.join(root, f): os.path.join(arcroot, f) for f in filenames})
+        arcroot = root[len(hostpath) :]
+        paths.update(
+            {os.path.join(root, d): os.path.join(arcroot, d) for d in dirnames}
+        )
+        paths.update(
+            {os.path.join(root, f): os.path.join(arcroot, f) for f in filenames}
+        )
     return paths
 
 
@@ -542,7 +547,9 @@ def add_conda_package_layers(image, hostpath, arcpath=None, filter=None, records
             if repodata_record["subdir"] == "noarch":
                 # we don't remap noarch package files
                 continue
-            base_id = repodata_record.get("sha256", repodata_record.get("md5") + 32*"0")
+            base_id = repodata_record.get(
+                "sha256", repodata_record.get("md5") + 32 * "0"
+            )
             # build layer, we need to use add_layer_paths() to deduplicate inodes,
             # i.e. properly capture hardlinks
             paths = _paths_from_record(record, hostpath)
@@ -553,7 +560,7 @@ def add_conda_package_layers(image, hostpath, arcpath=None, filter=None, records
         # add remaining packages / files into a single layer
         paths = {}
         for root, dirnames, filenames in os.walk(hostpath):
-            arcroot = root[len(hostpath):]
+            arcroot = root[len(hostpath) :]
             for name in dirnames + filenames:
                 host_name = os.path.join(root, name)
                 if host_name in files_in_layers:
@@ -562,11 +569,20 @@ def add_conda_package_layers(image, hostpath, arcpath=None, filter=None, records
         image.add_layer_paths(paths, filter=filter)
 
 
-def add_conda_layers(image, hostpath, arcpath=None, filter=None, records=None, layering_strategy="layered",):
+def add_conda_layers(
+    image,
+    hostpath,
+    arcpath=None,
+    filter=None,
+    records=None,
+    layering_strategy="layered",
+):
     if layering_strategy == "single":
         add_single_conda_layer(image, hostpath, arcpath=arcpath, filter=filter)
     elif layering_strategy == "layered":
-        add_conda_package_layers(image, hostpath, arcpath=arcpath, filter=filter, records=records)
+        add_conda_package_layers(
+            image, hostpath, arcpath=arcpath, filter=filter, records=records
+        )
     else:
         raise ValueError(f"layering strategy not recognized: {layering_strategy}")
 
@@ -612,7 +628,14 @@ def build_docker_environment(
                 channels_remap,
             )
 
-        add_conda_layers(image, str(tmpdir), arcpath="/", filter=conda_file_filter(), records=records, layering_strategy=layering_strategy)
+        add_conda_layers(
+            image,
+            str(tmpdir),
+            arcpath="/",
+            filter=conda_file_filter(),
+            records=records,
+            layering_strategy=layering_strategy,
+        )
 
         LOGGER.info(f"writing docker file to filesystem")
         with timer(LOGGER, "writing docker file"):

--- a/conda_docker/docker/base.py
+++ b/conda_docker/docker/base.py
@@ -15,7 +15,17 @@ from conda_docker.docker.tar import (
 
 class Layer:
     def __init__(
-        self, id, parent, architecture, os, created, author, checksum, size, content, config=None
+        self,
+        id,
+        parent,
+        architecture,
+        os,
+        created,
+        author,
+        checksum,
+        size,
+        content,
+        config=None,
     ):
         self.created = created
         self.author = author
@@ -46,9 +56,7 @@ class Layer:
             "WorkingDir": "",
             "Entrypoint": ["/bin/sh", "-c"],
             "OnBuild": None,
-            "Labels": {
-                "CONDA_DOCKER": VERSION,
-            }
+            "Labels": {"CONDA_DOCKER": VERSION,},
         }
 
     def list_files(self):
@@ -65,16 +73,16 @@ class Image:
     def remove_layer(self):
         self.layers.pop(0)
 
-    def add_layer_path(self, path, arcpath=None, recursive=True, filter=None, base_id=None):
+    def add_layer_path(
+        self, path, arcpath=None, recursive=True, filter=None, base_id=None
+    ):
         digest = write_tar_from_path(
             path, arcpath=arcpath, recursive=recursive, filter=filter
         )
         self._add_layer(digest, base_id=base_id)
 
     def add_layer_paths(self, paths, filter=None, base_id=None):
-        digest = write_tar_from_paths(
-            paths, filter=filter
-        )
+        digest = write_tar_from_paths(paths, filter=filter)
         self._add_layer(digest, base_id=base_id)
 
     def add_layer_contents(self, contents, filter=None, base_id=None):

--- a/conda_docker/docker/base.py
+++ b/conda_docker/docker/base.py
@@ -73,7 +73,7 @@ class Image:
 
     def add_layer_paths(self, paths, filter=None, base_id=None):
         digest = write_tar_from_paths(
-            path, arcpath=arcpath, recursive=recursive, filter=filter
+            paths, filter=filter
         )
         self._add_layer(digest, base_id=base_id)
 

--- a/conda_docker/docker/base.py
+++ b/conda_docker/docker/base.py
@@ -9,6 +9,7 @@ from conda_docker.docker.tar import (
     write_v1,
     write_tar_from_contents,
     write_tar_from_path,
+    write_tar_from_paths,
 )
 
 
@@ -64,29 +65,36 @@ class Image:
     def remove_layer(self):
         self.layers.pop(0)
 
-    def add_layer_path(self, path, arcpath=None, recursive=True, filter=None):
+    def add_layer_path(self, path, arcpath=None, recursive=True, filter=None, base_id=None):
         digest = write_tar_from_path(
             path, arcpath=arcpath, recursive=recursive, filter=filter
         )
-        self._add_layer(digest)
+        self._add_layer(digest, base_id=base_id)
 
-    def add_layer_contents(self, contents):
-        digest = write_tar_from_contents(contents)
-        self._add_layer(digest)
+    def add_layer_paths(self, paths, filter=None, base_id=None):
+        digest = write_tar_from_paths(
+            path, arcpath=arcpath, recursive=recursive, filter=filter
+        )
+        self._add_layer(digest, base_id=base_id)
 
-    def _add_layer(self, digest):
+    def add_layer_contents(self, contents, filter=None, base_id=None):
+        digest = write_tar_from_contents(contents, filter=filter)
+        self._add_layer(digest, base_id=base_id)
+
+    def _add_layer(self, digest, base_id=None):
         if len(self.layers) == 0:
             parent_id = None
         else:
             parent_id = self.layers[0].id
+        layer_id = secrets.token_hex(32) if base_id is None else base_id
 
         layer = Layer(
-            id=secrets.token_hex(32),
+            id=layer_id,
             parent=parent_id,
             architecture="amd64",
             os="linux",
             created=datetime.now(timezone.utc).astimezone().isoformat(),
-            author="conda_docker",
+            author="conda-docker",
             checksum=None,
             size=len(digest),
             content=digest,

--- a/conda_docker/docker/tar.py
+++ b/conda_docker/docker/tar.py
@@ -39,7 +39,7 @@ def _parse_v1_layer(tar, layer_id):
         author=d.get("author"),
         checksum=d.get("checksum"),
         size=d.get("size"),
-        config=d.get('config'),
+        config=d.get("config"),
         content=content,
     )
 
@@ -88,9 +88,9 @@ def write_v1_layer_metadata(layer):
     }
 
     metadata = {k: getattr(layer, k) for k in keys if getattr(layer, k) is not None}
-    metadata['config'] = layer.config
-    metadata['container_config'] = layer.config
-    return json.dumps(metadata).encode('utf-8')
+    metadata["config"] = layer.config
+    metadata["container_config"] = layer.config
+    return json.dumps(metadata).encode("utf-8")
 
 
 def write_v1_repositories(image):

--- a/conda_docker/docker/tar.py
+++ b/conda_docker/docker/tar.py
@@ -115,7 +115,7 @@ def write_tar_from_paths(paths, filter=None):
     """
     digest = io.BytesIO()
     with tarfile.TarFile(mode="w", fileobj=digest) as tar:
-        for path, arcpath in paths.items()
+        for path, arcpath in paths.items():
             tar.add(path, arcname=arcpath, recursive=False, filter=filter)
     digest.seek(0)
     return digest.getvalue()

--- a/setup.py
+++ b/setup.py
@@ -7,37 +7,35 @@ from setuptools import setup
 
 def main():
     """The main entry point."""
-    with open(os.path.join(os.path.dirname(__file__), 'README.md'), 'r') as f:
+    with open(os.path.join(os.path.dirname(__file__), "README.md"), "r") as f:
         readme = f.read()
     skw = dict(
-        name='conda-docker',
-        description='Create minimal docker images from conda environments',
+        name="conda-docker",
+        description="Create minimal docker images from conda environments",
         long_description=readme,
-        long_description_content_type='text/markdown',
-        license='BSD-3-Clause',
+        long_description_content_type="text/markdown",
+        license="BSD-3-Clause",
         version="0.0.1",
-        author='conda-forge',
-        maintainer='conda-forge',
-        author_email='conda-forge@googlegroups.com',
-        url='https://github.com/regro/conda-docker',
-        platforms='Cross Platform',
-        classifiers=['Programming Language :: Python :: 3'],
-        packages=['conda_docker', 'conda_docker.docker', 'conda_docker.registry'],
+        author="conda-forge",
+        maintainer="conda-forge",
+        author_email="conda-forge@googlegroups.com",
+        url="https://github.com/regro/conda-docker",
+        platforms="Cross Platform",
+        classifiers=["Programming Language :: Python :: 3"],
+        packages=["conda_docker", "conda_docker.docker", "conda_docker.registry"],
         package_dir={
-            'conda_docker': 'conda_docker',
-            'conda_docker.docker': 'conda_docker/docker',
-            'conda_docker.registry': 'conda_docker/registry',
+            "conda_docker": "conda_docker",
+            "conda_docker.docker": "conda_docker/docker",
+            "conda_docker.registry": "conda_docker/registry",
         },
-        package_data={'conda_docker': ['*.xsh']},
-        entry_points={
-            'console_scripts': ['conda-docker=conda_docker.cli:main'],
-        },
-        #install_requires=['xonsh', 'lazyasd', 'ruamel.yaml', 'tqdm', 'requests', 'dataclasses'],
+        package_data={"conda_docker": ["*.xsh"]},
+        entry_points={"console_scripts": ["conda-docker=conda_docker.cli:main"],},
+        # install_requires=['xonsh', 'lazyasd', 'ruamel.yaml', 'tqdm', 'requests', 'dataclasses'],
         python_requires=">=3.6",
         zip_safe=False,
-        )
+    )
     setup(**skw)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/test_conda.py
+++ b/tests/test_conda.py
@@ -22,6 +22,7 @@ class CondaMakeData:
     user_conda = default_prefix = None
     download_dir = precs = records = None
 
+
 @skip_if_conda_build
 @pytest.mark.incremental
 class TestCondaMake:


### PR DESCRIPTION
This implements the one-layer-per-package idea, with a couple of constraints. The first constraint is that it is difficult to know the file paths for noarch packages ahead of time. Additionally there is the 125 layer limit, which for safety I only allow 100 individiual package layers.

To get around these constraints all noarch packages and all packages after the initial 100 are combined into a single, last, squashed layer.  The packages are installed in dependency order, so base-level packages are more likely to get their own layer and be reused.

This is inspired by https://grahamc.com/blog/nix-and-layered-docker-images

CC @costrouc @mariusvniekerk 