### PR TITLE
Adding feature to expose api tobuild the docker image without saving to disk

### DIFF
--- a/conda_docker/conda.py
+++ b/conda_docker/conda.py
@@ -590,6 +590,23 @@ def build_docker_environment(
     channels_remap,
     layering_strategy="layered",
 ):
+    image = build_docker_environment_image(base_image, output_image, records, default_prefix, download_dir, user_conda, channels_remap, layering_strategy)
+
+    LOGGER.info(f"writing docker file to filesystem")
+    with timer(LOGGER, "writing docker file"):
+        image.write_file(output_filename)
+
+
+def build_docker_environment_image(
+    base_image,
+    output_image,
+    records,
+    default_prefix,
+    download_dir,
+    user_conda,
+    channels_remap,
+    layering_strategy="layered",
+):
     def parse_image_name(name):
         parts = name.split(":")
         if len(parts) == 1:
@@ -629,6 +646,4 @@ def build_docker_environment(
             layering_strategy=layering_strategy,
         )
 
-        LOGGER.info(f"writing docker file to filesystem")
-        with timer(LOGGER, "writing docker file"):
-            image.write_file(output_filename)
+        return image

--- a/news/feature-expose-docker-image-api.md
+++ b/news/feature-expose-docker-image-api.md
@@ -1,0 +1,5 @@
+**Changed:**
+
+* `build_docker_environment` refactored into two functions to expose
+  an internal function `build_docker_environment_image` to be used by
+  libraries e.g. conda-store


### PR DESCRIPTION
Long overdue PR to provide an api for working with conda_docker without saving the image to disk and directly working with the image. Going to use this feature to provide a docker registry via conda store https://github.com/Quansight/conda-store/tree/database/conda_store/registry.