### PR TITLE
Use shutil.copy to avoid "Invalid cross-device link" errors

### DIFF
--- a/conda_docker/utils.py
+++ b/conda_docker/utils.py
@@ -1,6 +1,8 @@
-import time
-import hashlib
 import contextlib
+import hashlib
+import os
+import platform
+import time
 
 
 @contextlib.contextmanager
@@ -20,3 +22,24 @@ def md5_files(paths):
                     break
                 h.update(chunk)
     return h.hexdigest()
+
+
+def can_link(source_dir, target_dir):
+    """Determines if we can link from source to target directory"""
+    if platform.system() == "Windows":
+        return False
+    src = os.path.join(source_dir, "__try_hardlinking_source__")
+    trg = os.path.join(target_dir, "__try_hardlinking_target__")
+    try:
+        with open(src, "w"):
+            pass
+        os.link(src, trg)
+        linkable = True
+    except OSError:
+        linkable = False
+    finally:
+        if os.path.isfile(trg):
+            os.remove(trg)
+        if os.path.isfile(src):
+            os.remove(src)
+    return linkable

--- a/news/cross-device-link.md
+++ b/news/cross-device-link.md
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Use copies if conda installation and temporary directory are on different devices
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Fixes this crash:
```bash
INFO:conda_docker.conda:building conda environment
Traceback (most recent call last):
  File "/home/cburr/miniconda3/bin/conda-docker", line 10, in <module>
    sys.exit(main())
  File "/home/cburr/miniconda3/lib/python3.7/site-packages/conda_docker/cli.py", line 121, in main
    cli(args)
  File "/home/cburr/miniconda3/lib/python3.7/site-packages/conda_docker/cli.py", line 26, in cli
    args.func(args)
  File "/home/cburr/miniconda3/lib/python3.7/site-packages/conda_docker/cli.py", line 114, in handle_conda_build
    layering_strategy=args.layering_strategy,
  File "/home/cburr/miniconda3/lib/python3.7/site-packages/conda_docker/conda.py", line 620, in build_docker_environment
    channels_remap,
  File "/home/cburr/miniconda3/lib/python3.7/site-packages/conda_docker/conda.py", line 411, in chroot_install
    os.link(orig_standalone, host_standalone)
OSError: [Errno 18] Invalid cross-device link: '/home/cburr/miniconda3/standalone_conda/conda.exe' -> '/tmp/tmp97bf35sd/_conda.exe'
```