### PR TITLE
Mamba json decode error

### DIFF
--- a/conda_docker/conda.py
+++ b/conda_docker/conda.py
@@ -186,7 +186,7 @@ def precs_from_package_specs(
     ), tempfile.TemporaryDirectory() as tmpdir:
         # need temp env prefix, just in case.
         json_listing = subprocess.check_output(
-            [solver_conda, "create", "--dry-run", "--prefix", str(tmpdir), "--json"]
+            [solver_conda, "create", "--dry-run", "--prefix", os.path.join(tmpdir, "prefix"), "--json"]
             + package_specs
         )
     listing = json.loads(json_listing)

--- a/news/json-decode-error.md
+++ b/news/json-decode-error.md
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* JSONDecodeError when using a list of package specification
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
The example in the README fails for me with:
```
INFO:conda_docker.conda:solving conda environment
INFO:conda_docker.conda:solving conda environment took 0.466 [s]
Traceback (most recent call last):
  File "/.../miniconda3/bin/conda-docker", line 8, in <module>
    sys.exit(main())
  File "/.../miniconda3/lib/python3.8/site-packages/conda_docker/cli.py", line 121, in main
    cli(args)
  File "/.../miniconda3/lib/python3.8/site-packages/conda_docker/cli.py", line 26, in cli
    args.func(args)
  File "/.../miniconda3/lib/python3.8/site-packages/conda_docker/cli.py", line 92, in handle_conda_build
    precs = find_precs(
  File "/.../miniconda3/lib/python3.8/site-packages/conda_docker/conda.py", line 244, in find_precs
    precs = precs_from_package_specs(
  File "/.../miniconda3/lib/python3.8/site-packages/conda_docker/conda.py", line 192, in precs_from_package_specs
    listing = json.loads(json_listing)
  File "/.../miniconda3/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/.../miniconda3/lib/python3.8/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/.../miniconda3/lib/python3.8/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```
